### PR TITLE
Add RPC authorization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ Usage
 -----
 
 ```
-docker run -d --name aria2_exporter -p 9578:9578 -e ARIA2_URL=http://aria2.example.com:6800 sbruder/aria2_exporter
+docker run -d --name aria2_exporter -p 9578:9578 \
+  -e ARIA2_URL=http://aria2.example.com:6800 \
+  -e ARIA2_RPC_SECRET=aria2-rpc-secret-token \
+  sbruder/aria2_exporter
 ```
 
-Replace aria2.example.com:6800 with the host and port of your aria2 instance.
+Replace `aria2.example.com:6800` with the host and port of your aria2 instance.
+
+Replace `aria2-rpc-secret-token` with the RPC secret authorization token if aria2
+is configured to use it or leave it blank otherwise.
 
 Metrics are available on http://localhost:9578/metrics


### PR DESCRIPTION
Hi,

It is argued that RPC authorization will become mandatory someday, so it would be useful to implement it.

https://aria2.github.io/manual/en/html/aria2c.html#rpc-authorization-secret-token
>To use RPC method-level authorization, the user has to specify an RPC secret authorization token using the `--rpc-secret` option. For each RPC method call, the caller has to include the token prefixed with `token:`. Even when the `--rpc-secret` option is not used, if the first parameter in the RPC method is a string and starts with` token:`, it will removed from the parameter list before the request is being processed.

My tests show that exporter works fine with both secret-protected and unprotected aria2 instances.

I've also added JSON-RPC error handling to let the user know about protocol level problems (e.g. authorization is configured but no token was specified).

Regards